### PR TITLE
bug with "Null" as class name - PHP 7

### DIFF
--- a/src/Logger/Null.php
+++ b/src/Logger/Null.php
@@ -23,7 +23,7 @@ namespace Goracash\Logger;
  *
  * This logger simply discards all messages.
  */
-class Null extends Primary
+class NewNameOfClass extends Primary
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Cannot use 'Null' as class name as it is reserved
